### PR TITLE
Add support for projects in DB

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -49,7 +49,7 @@ chrome.runtime.onMessage.addListener(
           });
         break;
       case MessageRequest.GET_ALL_ITEMS:
-        db.getAll()
+        db.getAllWebsites()
           .then((res) => sendResponse(res))
           .catch(err => {
             console.log(err)

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -33,6 +33,7 @@ export interface User {
 // functions seems a bit strange
 export class WebsiteStore {
   factory: IDBFactory;
+  db: IDBDatabase = null;
 
   constructor(factory: IDBFactory) {
     this.factory = factory;
@@ -40,6 +41,10 @@ export class WebsiteStore {
 
   private async getDb(): Promise<IDBDatabase> {
     return new Promise((resolve, reject) => {
+      if (this.db !== null) {
+        resolve(this.db)
+        return;
+      }
       let request = this.factory.open('rabbithole', version);
       request.onsuccess = () => {
         const db = request.result;
@@ -49,6 +54,7 @@ export class WebsiteStore {
           console.error(`Database error: ${event.target}`);
           reject(new Error("Database error"));
         };
+        this.db = db;
         resolve(db);
       };
       request.onerror = () => {

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -141,14 +141,12 @@ export class WebsiteStore {
 
       request.onsuccess = (event) => {
         console.log(`store item success: ${event.target}`);
-        db.close();
         resolve(item);
       };
 
       request.onerror = (event) => {
         console.log(`store item error`);
         console.log(event.target);
-        db.close();
         reject(new Error("Failed to store item"));
       };
     });
@@ -168,13 +166,11 @@ export class WebsiteStore {
 
       request.onsuccess = (_) => {
         console.log("getAll success");
-        db.close();
         resolve(request.result);
       };
 
       request.onerror = (event) => {
         console.log(`getAll error: ${event.target}`);
-        db.close();
         reject(new Error("Failed to retrieve items"));
       };
     });
@@ -198,14 +194,12 @@ export class WebsiteStore {
 
       request.onsuccess = (event) => {
         console.log(`update settings success: ${event.target}`);
-        db.close();
         resolve(settings);
       };
 
       request.onerror = (event) => {
         console.log(`update settings error`);
         console.log(event.target);
-        db.close();
         reject(new Error("Failed to update settings"));
       };
     });
@@ -224,7 +218,6 @@ export class WebsiteStore {
         .getAll();
 
       request.onsuccess = (_) => {
-        db.close();
         const [user] = request.result;
         console.log("getSettings success");
         resolve(user.settings);
@@ -232,7 +225,6 @@ export class WebsiteStore {
 
       request.onerror = (event) => {
         console.log(`getSettings error: ${event.target}`);
-        db.close();
         reject(new Error("Failed to retrieve settings"));
       };
     });
@@ -251,7 +243,6 @@ export class WebsiteStore {
         .getAll();
 
       request.onsuccess = (_) => {
-        db.close();
         const [user] = request.result;
         console.log("getUser success");
         console.log(request.result);
@@ -260,7 +251,6 @@ export class WebsiteStore {
 
       request.onerror = (event) => {
         console.log(`getUser error: ${event.target}`);
-        db.close();
         reject(new Error("Failed to retrieve user"));
       };
     });

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -51,7 +51,7 @@ export class WebsiteStore {
         resolve(db);
       };
       request.onerror = () => {
-        alert("Please allow Rabbithole to use storage!");
+        console.error("Please allow Rabbithole to use storage!");
         reject(new Error("Insufficient permissions"));
       }
     });
@@ -61,13 +61,13 @@ export class WebsiteStore {
   static async init(factory: IDBFactory): Promise<void> {
     await new Promise((resolve, reject) => {
       if (factory === undefined) {
-        // FIXME: this won't work on service worker
-        alert("This browser doesn't support Rabbithole! You should uninstall it :(");
+        console.error("This browser doesn't support Rabbithole! You should uninstall it :(");
         reject(new Error("indexedDB not supported"));
       } else {
         let request = factory.open('rabbithole', version);
-        request.onerror = () => {
-          alert("Please allow Rabbithole to use storage!");
+        request.onerror = (e) => {
+          console.error(e);
+          console.error("Please allow Rabbithole to use storage!");
           reject(new Error("Insufficient permissions"));
         }
 

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -145,9 +145,26 @@ export class WebsiteStore {
         .objectStore("savedWebsites")
         .add(item);
 
-      request.onsuccess = (event) => {
-        console.log(`store item success: ${event.target}`);
-        resolve(item);
+      request.onsuccess = async (event) => {
+        // update website list of active project
+        let currentProject = await this.getActiveProject();
+        currentProject.savedWebsites.push(item.url);
+
+        const projectRequest = db.transaction(["projects"], "readwrite")
+          .objectStore("projects")
+          .put(currentProject);
+
+        projectRequest.onsuccess = (event) => {
+          console.log(`store item success: ${event.target}`);
+          resolve(item);
+        }
+
+        projectRequest.onerror = (event) => {
+          console.log(`store item error`);
+          console.log(event.target);
+          reject(new Error("Failed to store item"));
+        };
+
       };
 
       request.onerror = (event) => {

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -8,7 +8,7 @@ export interface Settings {
 }
 
 export interface Website {
-  url: string;
+  url: string; // key
   name: string;
   savedAt: number;
   faviconUrl: string;
@@ -16,15 +16,16 @@ export interface Website {
   description?: string;
 };
 
-export interface Rabbithole {
-  id: string;
+export interface Project {
+  id: string; // key
   createdAt: number;
-  savedWebsites: Website[];
+  savedWebsites: string[]; // url/"foreign" key
   name: string;
 }
 
 export interface User {
-  id: string;
+  id: string; // key
+  currentProject: string;
   settings: Settings;
 }
 

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -130,7 +130,7 @@ export class WebsiteStore {
     });
   }
 
-  async getAll(): Promise<Website[]> {
+  async getAllWebsites(): Promise<Website[]> {
     return new Promise(async (resolve, reject) => {
       let db: IDBDatabase;
       try {


### PR DESCRIPTION
## Changes
- add a project store in the db
- add a default store where websites will be stored
- modify `user` to have an active project
- modify `store` to update the `savedWebsites` of an active project
- some fixes (singleton DB, stop closing DB unnecessarily, remove alerts from background script)

## Tests
- ensure all websites are saved to the `currentProject`
- ensure only one user is created across extension reloads
- ensure only one `Default Store` is created across extension reloads